### PR TITLE
Implement Z3Context.onError, called when z3 errors out.

### DIFF
--- a/src/main/java/z3/Z3Wrapper.java
+++ b/src/main/java/z3/Z3Wrapper.java
@@ -1,6 +1,7 @@
 package z3;
 
 import z3.Pointer;
+import z3.scala.Z3Context;
 
 import java.io.File;
 import java.io.InputStream;
@@ -9,6 +10,7 @@ import java.io.FileOutputStream;
 import java.util.Calendar;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
+import java.lang.ref.WeakReference;
 
 /** This class contains all the native functions. It should be accessed
  * mostly through the other classes, though. */
@@ -116,6 +118,21 @@ public final class Z3Wrapper {
             result[i] = ptrs[i].ptr;
         }
         return result;
+    }
+
+    private static HashMap<Long, WeakReference<Z3Context>> ptrToCtx = new HashMap<Long, WeakReference<Z3Context>>();
+
+    public static void onZ3Error(long contextPtr, long code) {
+        Z3Context ctx = ptrToCtx.get(Long.valueOf(contextPtr)).get();
+        ctx.onError(code);
+    }
+
+    public static void registerContext(long contextPtr, Z3Context ctx) {
+        ptrToCtx.put(Long.valueOf(contextPtr), new WeakReference<Z3Context>(ctx));
+    }
+
+    public static void unregisterContext(long contextPtr) {
+        ptrToCtx.remove(Long.valueOf(contextPtr));
     }
 
     public static native long mkConfig();

--- a/src/main/scala/z3/scala/Z3Context.scala
+++ b/src/main/scala/z3/scala/Z3Context.scala
@@ -19,6 +19,8 @@ object Z3Context {
 sealed class Z3Context(val config: Z3Config) {
   val ptr : Long = Z3Wrapper.mkContextRC(config.ptr)
 
+  Z3Wrapper.registerContext(ptr, this)
+
   val astQueue       = new Z3RefCountQueue[Z3ASTLike]()
   val astvectorQueue = new Z3RefCountQueue[Z3ASTVector]()
   val modelQueue     = new Z3RefCountQueue[Z3Model]()
@@ -40,9 +42,15 @@ sealed class Z3Context(val config: Z3Config) {
       astvectorQueue.clearQueue()
       tacticQueue.clearQueue()
 
+      Z3Wrapper.unregisterContext(this.ptr)
+
       Z3Wrapper.delContext(this.ptr)
       deleted = true
     }
+  }
+
+  def onError(code: Long): Nothing = {
+    throw new Exception("Unexpected Z3 error (code="+code+")")
   }
 
   @deprecated("Use interrupt instead", "")


### PR DESCRIPTION
Implements a callback for Z3 fatal errors. C will call Java's Z3Wrapper.onZ3Error which will dispatch to the right Z3Context.onError
