### PR TITLE
Use Z3_model_eval instead of the deprecated Z3_eval.

### DIFF
--- a/src/c/z3_Z3Wrapper.c
+++ b/src/c/z3_Z3Wrapper.c
@@ -1147,7 +1147,16 @@ JNIEXPORT jlong JNICALL Java_z3_Z3Wrapper_mkBVMulNoUnderflow (JNIEnv * env, jcla
 
     JNIEXPORT jboolean JNICALL Java_z3_Z3Wrapper_eval (JNIEnv * env, jclass cls, jlong contextPtr, jlong modelPtr, jlong astPtr, jobject ast) {
         Z3_ast newAST;
-        Z3_bool result = Z3_model_eval(asZ3Context(contextPtr), asZ3Model(modelPtr), asZ3AST(astPtr), 0, &newAST);
+        Z3_bool result = Z3_eval(asZ3Context(contextPtr), asZ3Model(modelPtr), asZ3AST(astPtr), &newAST);
+        jclass ac = (*env)->GetObjectClass(env, ast);
+        jfieldID fid = (*env)->GetFieldID(env, ac, "ptr", "J");
+        (*env)->SetLongField(env, ast, fid, astToJLong(newAST));
+        return (result == 0 ? JNI_FALSE : JNI_TRUE);
+    }
+
+    JNIEXPORT jboolean JNICALL Java_z3_Z3Wrapper_model_eval (JNIEnv * env, jclass cls, jlong contextPtr, jlong modelPtr, jlong astPtr, jobject ast, jboolean completion) {
+        Z3_ast newAST;
+        Z3_bool result = Z3_model_eval(asZ3Context(contextPtr), asZ3Model(modelPtr), asZ3AST(astPtr), completion, &newAST);
         jclass ac = (*env)->GetObjectClass(env, ast);
         jfieldID fid = (*env)->GetFieldID(env, ac, "ptr", "J");
         (*env)->SetLongField(env, ast, fid, astToJLong(newAST));

--- a/src/main/java/z3/Z3Wrapper.java
+++ b/src/main/java/z3/Z3Wrapper.java
@@ -361,7 +361,9 @@ public final class Z3Wrapper {
     public static native void delModel(long contextPtr, long modelPtr);
     public static native void modelIncRef(long contextPtr, long modelPtr);
     public static native void modelDecRef(long contextPtr, long modelPtr);
+    // decprecated
     public static native boolean eval(long contextPtr, long modelPtr, long astPtr, Pointer ast);
+    public static native boolean modelEval(long contextPtr, long modelPtr, long astPtr, Pointer ast, boolean completion);
     public static native int getModelNumConstants(long contextPtr, long modelPtr);
     public static native long getModelConstant(long contextPtr, long modelPtr, int i);
     public static native boolean isArrayValue(long contextPtr, long modelPtr, long astPtr, IntPtr numEntries);

--- a/src/main/scala/z3/scala/Z3Model.scala
+++ b/src/main/scala/z3/scala/Z3Model.scala
@@ -47,12 +47,12 @@ sealed class Z3Model private[z3](val ptr: Long, val context: Z3Context) extends 
     Z3Wrapper.modelDecRef(context.ptr, this.ptr)
   }
 
-  def eval(ast: Z3AST) : Option[Z3AST] = {
+  def eval(ast: Z3AST, completion: Boolean = false) : Option[Z3AST] = {
     if(this.ptr == 0L) {
       throw new IllegalStateException("The model is not initialized.")
     }
     val out = new Pointer(0L)
-    val result = Z3Wrapper.eval(context.ptr, this.ptr, ast.ptr, out)
+    val result = Z3Wrapper.modelEval(context.ptr, this.ptr, ast.ptr, out, completion)
     if (result) {
       Some(new Z3AST(out.ptr, context))
     } else {


### PR DESCRIPTION
For BC we set reconstruct_models to false, but it might be
avantageous to turn it on and let Z3 complete partial models instead of
doing it ourselves later (i.e. in Leon).
