### PR TITLE
Bundle libz3 within scalaz3.jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,82 +4,53 @@ ScalaZ3 for Scala 2.10
 This is ScalaZ3 for Scala 2.10 and Z3 4.3. Switch to the branch '2.9.x' for
 Scala 2.9 support.
 
-
-Downloading Z3
-=================
-
-Z3 can be downloaded from the [Z3 download site](http://z3.codeplex.com/)
-
-
 Compiling ScalaZ3
 =================
 
-Setup steps, for Linux
+Prerequisites
+----------------------
+You should have Java and SBT 0.13.x installed.
+
+Linux
 ----------------------
 
-1) Download Z3, and copy the include and lib files to z3/[z3version]/include and
-z3/[z3version]/lib respectively. (eg: z3/4.3-unix-64b/include/z3.h and
+1) Download Z3 source code from http://z3.codeplex.com/, compile it, and copy
+the headers and built library to z3/[z3version]/include and z3/[z3version]/lib
+respectively. (eg: z3/4.3-unix-64b/include/z3.h and
 z3/4.3-unix-64b/lib/libz3.so).
 
-2) Download sbt 0.12.x.
+2) Run 'sbt package' to create the jar file. It will be in
+'target/scala-2.10/scalaz3\_2.10-2.0.jar' and will contain the shared library
+dependencies.
 
-3) Run 'sbt package' to create the jar file. It will be in
-target/[scalaversion]/scalaz3....jar and will contain the shared
-library required by the bindings.
+3) For testing, run
 
-4) For testing, run
+    sbt test
 
-    LD_LIBRARY_PATH=z3/[z3version]/lib sbt test
-
-Alternatively, start a console by running
-
-    LD_LIBRARY_PATH=z3/[z3version]/lib scala -cp target/[scalaversion]scalaz3.jar
-
-then try, e.g.,
-
-    println(z3.scala.version).
-
-Setup steps, for Mac
+Mac
 ----------------------
 
-1) Download Z3, and copy the include and lib files to z3/[z3version]/include and
-z3/[z3version]/lib respectively. (eg: z3/4.3-osx-64b/include/z3.h and
-z3/4.3-osx-64b/lib/libz3.so).
+1) Download Z3 source code from http://z3.codeplex.com/, compile it, and copy
+the headers and built library to z3/[z3version]/include and z3/[z3version]/lib
+respectively. (eg: z3/4.3-unix-64b/include/z3.h and
+z3/4.3-unix-64b/lib/libz3.dnylib).
 
-2) Download sbt 0.12.x.
+2) Run 'sbt package' to create the jar file. It will be in
+'target/scala-2.10/scalaz3\_2.10-2.0.jar' and will contain the shared library
+dependencies.
 
-3) Run 'sbt package' to create the jar file. It will be in
-target/[scalaversion]/scalaz3....jar and will contain the shared
-library required by the bindings.
+3) For testing, run
 
-4) For testing, run
+    sbt test
 
-    DYLD_LIBRARY_PATH=z3/[z3version]/lib sbt test
+Windows
+----------------------
 
-Alternatively, start a console by running
+1) Download Cygwin, and install packages for gcc.
 
-    DYLD_LIBRARY_PATH=z3/[z3version]/lib scala -cp target/[scalaversion]scalaz3.jar
+2) Download Z3 4.3 release, and copy libz3.dll to z3/[z3version]/bin and
+include/\*.h to /z3/[z3version]/include/. (eg: z3/4.3-win-64b/bin/libz3.dll)
 
-then try, e.g.,
-
-    println(z3.scala.version).
-
-Setup steps, for Windows
-------------------------
-
-A) Download and install Z3 using the .msi installer
-
-B) Download sbt (see 2 above).
-
-C) The 'package' command in the current build script does not work with
-Windows; there is no equivalent for the gcc command. Run 'javah' so that it
-compiles the Java/Scala sources and generates the JNI header files.
-
-D) Assuming you have copied the 'include' and 'bin' directories from the Z3
-distribution in z3/[z3version], the following command should compile the shared
-library, assuming you have installed MinGW:
-
-    gcc -shared -o lib-bin\scalaz3.dll -D_JNI_IMPLEMENTATION_ -Wl,--kill-at -I "[jdkpath]\include" -I "[jdkpath]\include\win32" -I z3\[z3version]\include src\c\*.h src\c\*.c z3\[z3version]\bin\z3.lib
-
-E) You can manually create a jar with the contents of target/[scalaversion] and
-lib-bin.
+3) Run 'sbt package' to create the jar file. It will end up in
+'target/scala2.10/scalaz3\_2.10-2.0.jar' and will contain the shared library
+dependencies.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.2
+sbt.version=0.13.0

--- a/src/main/java/z3/Z3Wrapper.java
+++ b/src/main/java/z3/Z3Wrapper.java
@@ -10,14 +10,23 @@ import java.io.FileOutputStream;
 import java.util.Calendar;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
+import java.util.Vector;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipEntry;
+import java.security.CodeSource;
+import java.net.URL;
 
 /** This class contains all the native functions. It should be accessed
  * mostly through the other classes, though. */
 public final class Z3Wrapper {
     // related to the path in the jar file
-	private static final String LIB_SEPARATOR = "/";
-    private static final String LIB_BIN = LIB_SEPARATOR + "lib-bin" + LIB_SEPARATOR;
+    private static final String DS = java.io.File.separator;
+    private static final String PS = java.io.File.pathSeparator;
+
+    private static final String LIB_BIN = DS + "lib-bin" + DS;
     // the root name of the library file. lib....so in Linux, lib....jnilib in MacOS, ....dll in Windows, etc.
     private static final String LIB_NAME = "scalaz3";
     private static final String Z3_LIB_NAME = "z3";
@@ -26,22 +35,27 @@ public final class Z3Wrapper {
 
     private static final String versionString = LibraryChecksum.value;
 
+    //private static final String isDebug = System.getProperty("scalaz3.debug.load");
+    private static final String isDebug = "aaa";
+
     // this is just to force class loading, and therefore library loading.
     static {
-        try {
-            // System.out.println("Looking for Library " + LIB_NAME + " in System path" );
-            System.loadLibrary(LIB_NAME);
-        } catch (UnsatisfiedLinkError e) {
-            // Convert root to: lib....so in Linux, lib....jnilib in MacOS, ....dll in Windows, etc.
-            String name = System.mapLibraryName(LIB_NAME);
+      if (!withinJar()) {
+        System.err.println("It seems you are not running ScalaZ3 from its JAR");
+        System.exit(1);
+      }
 
-            if (withinJar()) {
-                loadFromJar();
-            } else {
-                String curDir = System.getProperty("user.dir");
-                System.load(curDir + LIB_BIN + name );
-            }
+      loadFromJar();
+    }
+
+    private static void debug(String msg) {
+        if (isDebug != null) {
+          System.out.println(msg);
         }
+    }
+
+    public static void main(String[] args) {
+	System.out.println("yay");
     }
 
     public static boolean withinJar() {
@@ -65,47 +79,69 @@ public final class Z3Wrapper {
 
     private static void loadFromJar() {
         String path = "SCALAZ3_" + versionString;
-        loadLib(path, Z3_LIB_NAME, true);
-        loadLib(path, LIB_NAME, false);
+        File libDir  = new File(System.getProperty("java.io.tmpdir") + DS + path + LIB_BIN);
+
+        String libRealName   = System.mapLibraryName(LIB_NAME);
+        String z3LibRealName = System.mapLibraryName(Z3_LIB_NAME);
+
+        try {
+          if (!libDir.isDirectory() || !libDir.canRead()) {
+            libDir.mkdirs();
+            extractFromJar(libDir);
+          }
+
+          addLibraryPath(libDir.getAbsolutePath());
+
+          debug("Loading "+LIB_NAME);
+          System.loadLibrary(LIB_NAME);
+        } catch (Exception e) {
+          System.err.println(e.getMessage());
+          e.printStackTrace();
+        }
     }
 
-    private static void loadLib(String path, String name, boolean optional) {
-        name = System.mapLibraryName(name);
-        String completeFileName = LIB_BIN + name;
-        File fileOut = new File(System.getProperty("java.io.tmpdir") + "/" + path + completeFileName);
-        //System.out.println("I'll be looking for the library as: " + fileOut);
+    public static void addLibraryPath(String pathToAdd) throws Exception {
+        System.setProperty("java.library.path", pathToAdd + PS + System.getProperty("java.library.path"));
 
-        if(fileOut.isFile() && fileOut.canRead()) {
-            // Library has been copied in the past, we can just load it from there.
-            //System.out.println("Looks like I found it !");
-            System.load(fileOut.toString());
-        } else {
-            // Couldn't find the library, so we can copy before we can load it.
-            try {
-                //System.out.println("Oh no, I have to extract it from the jar file !");
-                //System.out.println("Looking for " + completeFileName + " in the jar file...");
-                InputStream in = Z3Wrapper.class.getResourceAsStream(completeFileName);
-                if (in==null && optional)
-                    return; // we ignore this
-                if (in==null)
-                    throw new java.io.FileNotFoundException("Could not find " + completeFileName);
+        // this forces JVM to reload "java.library.path" property
+        Field fieldSysPath = ClassLoader.class.getDeclaredField( "sys_paths" );
+        fieldSysPath.setAccessible( true );
+        fieldSysPath.set( null, null );
+    }
 
-                fileOut.getParentFile().mkdirs();
-                fileOut.createNewFile();
-                OutputStream out = new FileOutputStream(fileOut);
-                byte buf[] = new byte[4096];
-                int len;
-                while((len = in.read(buf)) > 0) {
-                    out.write(buf, 0, len);
+
+    private static void extractFromJar(File toDir) throws Exception {
+        CodeSource src = Z3Wrapper.class.getProtectionDomain().getCodeSource();
+        if (src != null) {
+            URL jar = src.getLocation();
+            ZipInputStream zip = new ZipInputStream(jar.openStream());
+            while(true) {
+                ZipEntry e = zip.getNextEntry();
+                if (e == null) break;
+
+                String path = e.getName();
+
+                if (path.startsWith("lib-bin/") && !e.isDirectory()) {
+
+                    String name = new File(path).getName();
+
+                    debug("Extracting "+path+" from jar to "+name+ "...");
+
+                    File to = new File(toDir.getAbsolutePath() + DS + name);
+
+                    InputStream in   = Z3Wrapper.class.getResourceAsStream("/"+path);
+                    OutputStream out = new FileOutputStream(to);
+                    byte buf[] = new byte[4096];
+                    int len;
+                    while((len = in.read(buf)) > 0) {
+                        out.write(buf, 0, len);
+                    }
+                    out.close();
+                    in.close();
                 }
-                out.close();
-                in.close();
-                System.load(fileOut.toString());
-            } catch (Exception e) {
-                System.err.println(e.getMessage());
-                e.printStackTrace();
             }
         }
+
     }
 
     /** Placeholder class to ease JNI interaction. */


### PR DESCRIPTION
The loading of the libz3 is now deterministic, no more LD_LIBRARY_PATH
needed. libscalaz3/libz3 are always expected to be extracted to
<tmp>/SCALAZ3_<checksum>.

Works on linux and mac, untested on windows.
