### PR TITLE
Make needed changes to the build to facilitate having 2.11 cross-compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,20 @@ scalacOptions += "-unchecked"
 
 scalacOptions += "-feature"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.10.4"
+
+crossScalaVersions := Seq("2.10.4", "2.11.1")
 
 libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "1.9.1" % "test"
+    "org.scalatest" %% "scalatest" % "2.1.3" % "test"
 )
+
+libraryDependencies ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    // if scala 2.11+ is used, add dependency on scala-xml module
+    case Some((2, scalaMajor)) if scalaMajor >= 11 => Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.2")
+    case _                                         => Seq.empty
+  }
+}
 
 fork in Test := true

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -112,7 +112,7 @@ object ScalaZ3build extends Build {
   val javahTask = (streams, dependencyClasspath in Compile, classDirectory in Compile) map {
     case (s, deps, cd) =>
 
-      deps.map(_.data.absolutePath).find(_.endsWith("lib" + DS + "scala-library.jar")) match {
+      deps.map(_.data.absolutePath).find(_.contains("scala-library")) match {
         case Some(lib) =>
           s.log.info("Preparing JNI headers...")
           exec("javah -classpath " + cd.absolutePath + PS + lib + " -d " + cPath.absolutePath + " " + natives.mkString(" "), s)
@@ -124,7 +124,7 @@ object ScalaZ3build extends Build {
   } dependsOn(compile.in(Compile))
 
   def extractDir(checksum: String): String = {
-    System.getProperty("java.io.tmpdir") + DS + "SCALAZ3_" + checksum + DS + "lib-bin" + DS   
+    System.getProperty("java.io.tmpdir") + DS + "SCALAZ3_" + checksum + DS + "lib-bin" + DS
   }
 
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5


### PR DESCRIPTION
Don't know if using 2.11 is interesting for this project.
Checked that it works with `$ sbt ";+clean;+package;+test"` on mac os 10.9.3, will also be able to check this on a linux machine over the weekend.
