### PR TITLE
Mac-specific JDK include path

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,6 +19,7 @@ object ScalaZ3build extends Build {
   lazy val libBinFilePath   = libBinPath / soName
   lazy val jdkIncludePath   = file(System.getProperty("java.home")) / ".." / "include"
   lazy val jdkUnixIncludePath = jdkIncludePath / "linux"
+  lazy val jdkMacIncludePath  = jdkIncludePath / "darwin"
   lazy val jdkWinIncludePath  = jdkIncludePath / "win32"
 
   lazy val osInf: String = Option(System.getProperty("os.name")).getOrElse("")
@@ -169,6 +170,7 @@ object ScalaZ3build extends Build {
              "-dynamiclib" + " " +
              "-install_name "+extractDir(cs)+soName + " " +
              "-I" + jdkIncludePath.absolutePath + " " +
+             "-I" + jdkMacIncludePath.absolutePath + " " +
              "-I" + frameworkPath + " " +
              "-I" + z3IncludePath.absolutePath + " " +
              "-L" + z3LibPath.absolutePath + " " +


### PR DESCRIPTION
Fixed a compilation error on OS X 10.10 with JDK 1.7.0_65.

gcc could not find jni_md.h, which is in a OS X-specific folder now.
