### PR TITLE
Remove -fopenmp on Mac

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -230,7 +230,7 @@ object ScalaZ3Build extends Build {
            "-L" + z3BuildPath.absolutePath + " " +
            "-g -lc " +
            "-Wl,-rpath,"+extractDir(cs)+" " +
-           "-lz3 -fPIC -O2 -fopenmp", s)
+           "-lz3 -fPIC -O2", s)
 
     } else {
       error("Unknown arch: "+osInf+" - "+osArch)


### PR DESCRIPTION
Apple has replaced gcc by clang since a few years now, but their version of clang seems to lack support for `-fopenmp`. Removing this option allows one to successfully run `sbt package` (which was only silently failing before this change) and therefore use it on OS X.