### PR TITLE
Make Z3Solver.assertCnstr(dsl.Tree[dsl.BoolSort]) public

### DIFF
--- a/src/main/scala/z3/scala/Z3Solver.scala
+++ b/src/main/scala/z3/scala/Z3Solver.scala
@@ -100,7 +100,7 @@ class Z3Solver private[z3](val ptr: Long, val context: Z3Context) extends Z3Obje
     (checkAssumptions(assumptions : _*), if (isModelAvailable) getModel() else null, getUnsatCore())
   }
 
-  private[z3] def assertCnstr(tree : dsl.Tree[dsl.BoolSort]) : Unit = {
+  def assertCnstr(tree : dsl.Tree[dsl.BoolSort]) : Unit = {
     assertCnstr(tree.ast(context))
   }
 


### PR DESCRIPTION
Examples in the test source directory use this method (cf. NQueens for instance).
However, I can't use it in my own projects as it is package private.