### PR TITLE
Add dsl bindings to bit-vectors

### DIFF
--- a/src/main/scala/z3/scala/Z3Context.scala
+++ b/src/main/scala/z3/scala/Z3Context.scala
@@ -720,6 +720,10 @@ sealed class Z3Context(val config: Map[String, String]) {
     new Z3AST(Native.mkZeroExt(this.ptr, extraSize, ast.ptr), this)
   }
 
+  def mkRepeat(count: Int, ast: Z3AST) : Z3AST = {
+    new Z3AST(Native.mkRepeat(this.ptr, count, ast.ptr), this)
+  }
+
   def mkBVShl(ast1: Z3AST, ast2: Z3AST) : Z3AST = {
     new Z3AST(Native.mkBvshl(this.ptr, ast1.ptr, ast2.ptr), this)
   }
@@ -742,6 +746,34 @@ sealed class Z3Context(val config: Map[String, String]) {
 
   def mkBVAddNoOverflow(ast1: Z3AST, ast2: Z3AST, isSigned: Boolean) : Z3AST = {
     new Z3AST(Native.mkBvaddNoOverflow(this.ptr, ast1.ptr, ast2.ptr, isSigned), this)
+  }
+
+  def mkBVAddNoUnderflow(ast1: Z3AST, ast2: Z3AST) : Z3AST = {
+    new Z3AST(Native.mkBvaddNoUnderflow(this.ptr, ast1.ptr, ast2.ptr), this)
+  }
+
+  def mkBVSubNoOverflow(ast1: Z3AST, ast2: Z3AST) : Z3AST = {
+    new Z3AST(Native.mkBvsubNoOverflow(this.ptr, ast1.ptr, ast2.ptr), this)
+  }
+
+  def mkBVSubNoUnderflow(ast1: Z3AST, ast2: Z3AST, isSigned: Boolean) : Z3AST = {
+    new Z3AST(Native.mkBvsubNoUnderflow(this.ptr, ast1.ptr, ast2.ptr, isSigned), this)
+  }
+
+  def mkBVSDivNoOverflow(ast1: Z3AST, ast2: Z3AST) : Z3AST = {
+    new Z3AST(Native.mkBvsdivNoOverflow(this.ptr, ast1.ptr, ast2.ptr), this)
+  }
+
+  def mkBVNegNoOverflow(ast: Z3AST) : Z3AST = {
+    new Z3AST(Native.mkBvnegNoOverflow(this.ptr, ast.ptr), this)
+  }
+
+  def mkBVMulNoOverflow(ast1: Z3AST, ast2: Z3AST, isSigned: Boolean) : Z3AST = {
+    new Z3AST(Native.mkBvmulNoOverflow(this.ptr, ast1.ptr, ast2.ptr, isSigned), this)
+  }
+
+  def mkBVMulNoUnderflow(ast1: Z3AST, ast2: Z3AST) : Z3AST = {
+    new Z3AST(Native.mkBvmulNoUnderflow(this.ptr, ast1.ptr, ast2.ptr), this)
   }
 
   def getFuncDecl(op: Z3DeclKind, sorts: Z3Sort*): Z3FuncDecl = {

--- a/src/main/scala/z3/scala/Z3Context.scala
+++ b/src/main/scala/z3/scala/Z3Context.scala
@@ -592,6 +592,14 @@ sealed class Z3Context(val config: Map[String, String]) {
     new Z3Sort(Native.mkBvSort(this.ptr, size), this)
   }
 
+  def mkInt2BV(size: Int, ast: Z3AST) : Z3AST = {
+    new Z3AST(Native.mkInt2bv(this.ptr, size, ast.ptr), this)
+  }
+
+  def mkBV2Int(ast: Z3AST, isSigned: Boolean) : Z3AST = {
+    new Z3AST(Native.mkBv2int(this.ptr, ast.ptr, isSigned), this)
+  }
+
   def mkBVNot(ast: Z3AST) : Z3AST = {
     new Z3AST(Native.mkBvnot(this.ptr, ast.ptr), this)
   }

--- a/src/main/scala/z3/scala/Z3Model.scala
+++ b/src/main/scala/z3/scala/Z3Model.scala
@@ -18,6 +18,14 @@ object Z3Model {
     else
       model.context.getBoolValue(res.get)
   }
+
+  implicit def ast2char(model: Z3Model, ast: Z3AST): Option[Char] = {
+    val res = model.eval(ast)
+    if (res.isEmpty)
+      None
+    else
+      model.context.getNumeralInt(res.get).value.map(_.toChar)
+  }
 }
 
 sealed class Z3Model private[z3](val ptr: Long, val context: Z3Context) extends Z3Object {

--- a/src/main/scala/z3/scala/dsl/Operands.scala
+++ b/src/main/scala/z3/scala/dsl/Operands.scala
@@ -85,6 +85,188 @@ object Operands {
     }
   }
 
+  class BitVectorOperand private[dsl](val tree : Tree[_ >: BottomSort <: BVSort]) {
+    def unary_~ : BitVectorOperand = {
+      new BitVectorOperand(BVNot(tree))
+    }
+
+    def reducedAnd : BitVectorOperand = {
+      new BitVectorOperand(BVRedAnd(tree))
+    }
+
+    def reducedOr : BitVectorOperand = {
+      new BitVectorOperand(BVRedOr(tree))
+    }
+
+    def |(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVOr(tree, other.tree))
+    }
+
+    def &(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVAnd(tree, other.tree))
+    }
+
+    def ^(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVXor(tree, other.tree))
+    }
+
+    def nand(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVNand(tree, other.tree))
+    }
+
+    def nor(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVNor(tree, other.tree))
+    }
+
+    def xnor(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVXnor(tree, other.tree))
+    }
+
+    def unary_- : BitVectorOperand = {
+      new BitVectorOperand(BVNeg(tree))
+    }
+
+    def *(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVMul(tree, other.tree))
+    }
+
+    def -(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVSub(tree, other.tree))
+    }
+
+    def ~/(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVUdiv(tree, other.tree))
+    }
+
+    def /(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVSdiv(tree, other.tree))
+    }
+
+    def %(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVSmod(tree, other.tree))
+    }
+
+    def urem(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVUrem(tree, other.tree))
+    }
+
+    def srem(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVSrem(tree, other.tree))
+    }
+
+    def ===(other : BitVectorOperand) : BoolOperand = {
+      new BoolOperand(Eq(tree, other.tree))
+    }
+
+    def !==(other : BitVectorOperand) : BoolOperand = {
+      new BoolOperand(Distinct(tree, other.tree))
+    }
+
+    def ~<(other : BitVectorOperand) : BoolOperand = {
+      new BoolOperand(BVUlt(tree, other.tree))
+    }
+
+    def ~<=(other : BitVectorOperand) : BoolOperand = {
+      new BoolOperand(BVUle(tree, other.tree))
+    }
+
+    def ~>(other : BitVectorOperand) : BoolOperand = {
+      new BoolOperand(BVUgt(tree, other.tree))
+    }
+
+    def ~>=(other : BitVectorOperand) : BoolOperand = {
+      new BoolOperand(BVUge(tree, other.tree))
+    }
+
+    def <(other : BitVectorOperand) : BoolOperand = {
+      new BoolOperand(BVSlt(tree, other.tree))
+    }
+
+    def <=(other : BitVectorOperand) : BoolOperand = {
+      new BoolOperand(BVSle(tree, other.tree))
+    }
+
+    def >(other : BitVectorOperand) : BoolOperand = {
+      new BoolOperand(BVSgt(tree, other.tree))
+    }
+
+    def >=(other : BitVectorOperand) : BoolOperand = {
+      new BoolOperand(BVSge(tree, other.tree))
+    }
+
+    def concat(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(Concat(tree, other.tree))
+    }
+
+    def extract(high: Int, low: Int) : BitVectorOperand = {
+      new BitVectorOperand(Extract(high, low, tree))
+    }
+
+    def signExt(extraSize: Int) : BitVectorOperand = {
+      new BitVectorOperand(SignExt(extraSize, tree))
+    }
+
+    def zeroExt(extraSize: Int) : BitVectorOperand = {
+      new BitVectorOperand(ZeroExt(extraSize, tree))
+    }
+
+    def repeat(count: Int) : BitVectorOperand = {
+      new BitVectorOperand(Repeat(count, tree))
+    }
+
+    def <<(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVShl(tree, other.tree))
+    }
+
+    def >>(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVAshr(tree, other.tree))
+    }
+
+    def >>>(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVLshr(tree, other.tree))
+    }
+
+    def rotateLeft(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(ExtRotateLeft(tree, other.tree))
+    }
+
+    def rotateRight(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(ExtRotateRight(tree, other.tree))
+    }
+
+    def addNoOverflow(other : BitVectorOperand, isSigned: Boolean) : BitVectorOperand = {
+      new BitVectorOperand(BVAddNoOverflow(tree, other.tree, isSigned))
+    }
+
+    def addNoUnderflow(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVAddNoUnderflow(tree, other.tree))
+    }
+
+    def subNoOverflow(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVSubNoOverflow(tree, other.tree))
+    }
+
+    def subNoUnderflow(other : BitVectorOperand, isSigned: Boolean) : BitVectorOperand = {
+      new BitVectorOperand(BVSubNoUnderflow(tree, other.tree, isSigned))
+    }
+
+    def sdivNoOverflow(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVSDivNoOverflow(tree, other.tree))
+    }
+
+    def negNoOverflow : BitVectorOperand= {
+      new BitVectorOperand(BVNegNoOverflow(tree))
+    }
+
+    def mulNoOverflow(other : BitVectorOperand, isSigned: Boolean) : BitVectorOperand = {
+      new BitVectorOperand(BVMulNoOverflow(tree, other.tree, isSigned))
+    }
+
+    def mulNoUnderflow(other : BitVectorOperand) : BitVectorOperand = {
+      new BitVectorOperand(BVMulNoUnderflow(tree, other.tree))
+    }
+  }
+
   class SetOperand private[dsl](val tree : Tree[_ >: BottomSort <: SetSort]) {
     def ++(other : SetOperand) : SetOperand = {
       new SetOperand(SetUnion(tree, other.tree))

--- a/src/main/scala/z3/scala/dsl/Trees.scala
+++ b/src/main/scala/z3/scala/dsl/Trees.scala
@@ -177,6 +177,182 @@ case class GE[+A >: BottomSort <: IntSort](left : Tree[A], right : Tree[A]) exte
   private[dsl] def build(z3 : Z3Context) = z3.mkGE(left.ast(z3), right.ast(z3))
 }
 
+case class BVNot[+A >: BottomSort <: BVSort](tree : Tree[A]) extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVNot(tree.ast(z3))
+}
+
+case class BVRedAnd[+A >: BottomSort <: BVSort](tree : Tree[A]) extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVRedAnd(tree.ast(z3))
+}
+
+case class BVRedOr[+A >: BottomSort <: BVSort](tree : Tree[A]) extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVRedOr(tree.ast(z3))
+}
+
+case class BVAnd[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVAnd(left.ast(z3), right.ast(z3))
+}
+
+case class BVOr[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVOr(left.ast(z3), right.ast(z3))
+}
+
+case class BVXor[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVXor(left.ast(z3), right.ast(z3))
+}
+
+case class BVNand[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVNand(left.ast(z3), right.ast(z3))
+}
+
+case class BVNor[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVNor(left.ast(z3), right.ast(z3))
+}
+
+case class BVXnor[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVXnor(left.ast(z3), right.ast(z3))
+}
+
+case class BVNeg[+A >: BottomSort <: BVSort](tree : Tree[A]) extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVNeg(tree.ast(z3))
+}
+
+case class BVAdd[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVAdd(left.ast(z3), right.ast(z3))
+}
+
+case class BVSub[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSub(left.ast(z3), right.ast(z3))
+}
+
+case class BVMul[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVMul(left.ast(z3), right.ast(z3))
+}
+
+case class BVUdiv[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVUdiv(left.ast(z3), right.ast(z3))
+}
+
+case class BVSdiv[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSdiv(left.ast(z3), right.ast(z3))
+}
+
+case class BVUrem[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVUrem(left.ast(z3), right.ast(z3))
+}
+
+case class BVSrem[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSrem(left.ast(z3), right.ast(z3))
+}
+
+case class BVSmod[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSmod(left.ast(z3), right.ast(z3))
+}
+
+case class BVUlt[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryPred[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVUlt(left.ast(z3), right.ast(z3))
+}
+
+case class BVSlt[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryPred[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSlt(left.ast(z3), right.ast(z3))
+}
+
+case class BVUle[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryPred[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVUle(left.ast(z3), right.ast(z3))
+}
+
+case class BVSle[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryPred[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSle(left.ast(z3), right.ast(z3))
+}
+
+case class BVUgt[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryPred[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVUgt(left.ast(z3), right.ast(z3))
+}
+
+case class BVSgt[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryPred[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSgt(left.ast(z3), right.ast(z3))
+}
+
+case class BVUge[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryPred[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVUge(left.ast(z3), right.ast(z3))
+}
+
+case class BVSge[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryPred[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSge(left.ast(z3), right.ast(z3))
+}
+
+case class Concat[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkConcat(left.ast(z3), right.ast(z3))
+}
+
+case class Extract[+A >: BottomSort <: BVSort](high: Int, low: Int, tree : Tree[A]) extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkExtract(high, low, tree.ast(z3))
+}
+
+case class SignExt[+A >: BottomSort <: BVSort](extraSize: Int, tree : Tree[A]) extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkSignExt(extraSize, tree.ast(z3))
+}
+
+case class ZeroExt[+A >: BottomSort <: BVSort](extraSize: Int, tree : Tree[A]) extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkZeroExt(extraSize, tree.ast(z3))
+}
+
+case class Repeat[+A >: BottomSort <: BVSort](count: Int, tree : Tree[A]) extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkRepeat(count, tree.ast(z3))
+}
+
+case class BVShl[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVShl(left.ast(z3), right.ast(z3))
+}
+
+case class BVLshr[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVLshr(left.ast(z3), right.ast(z3))
+}
+
+case class BVAshr[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVAshr(left.ast(z3), right.ast(z3))
+}
+
+case class ExtRotateLeft[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkExtRotateLeft(left.ast(z3), right.ast(z3))
+}
+
+case class ExtRotateRight[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkExtRotateRight(left.ast(z3), right.ast(z3))
+}
+
+case class BVAddNoOverflow[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A], isSigned: Boolean) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVAddNoOverflow(left.ast(z3), right.ast(z3), isSigned)
+}
+
+case class BVAddNoUnderflow[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVAddNoUnderflow(left.ast(z3), right.ast(z3))
+}
+
+case class BVSubNoOverflow[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSubNoOverflow(left.ast(z3), right.ast(z3))
+}
+
+case class BVSubNoUnderflow[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A], isSigned: Boolean) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSubNoUnderflow(left.ast(z3), right.ast(z3), isSigned)
+}
+
+case class BVSDivNoOverflow[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVSDivNoOverflow(left.ast(z3), right.ast(z3))
+}
+
+case class BVNegNoOverflow[+A >: BottomSort <: BVSort](tree : Tree[A]) extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVNegNoOverflow(tree.ast(z3))
+}
+
+case class BVMulNoOverflow[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A], isSigned: Boolean) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVMulNoOverflow(left.ast(z3), right.ast(z3), isSigned)
+}
+
+case class BVMulNoUnderflow[+A >: BottomSort <: BVSort](left : Tree[A], right : Tree[A]) extends BinaryOp[A,BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkBVMulNoUnderflow(left.ast(z3), right.ast(z3))
+}
+
 case class SetUnion[+A >: BottomSort <: SetSort](args: Tree[A]*) extends Tree[SetSort] {
   private[dsl] def build(z3 : Z3Context) = z3.mkSetUnion(args.map(_.ast(z3)) : _*)
 }

--- a/src/main/scala/z3/scala/dsl/Trees.scala
+++ b/src/main/scala/z3/scala/dsl/Trees.scala
@@ -93,12 +93,20 @@ case class IntConstant(value : Int) extends Tree[IntSort] {
   private[dsl] def build(z3 : Z3Context) = z3.mkInt(value, z3.mkIntSort)
 }
 
+case class CharConstant(value : Char) extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkInt(value, z3.mkBVSort(16))
+}
+
 case class BoolVar() extends Tree[BoolSort] {
   private[dsl] def build(z3 : Z3Context) = z3.mkFreshConst("C", z3.mkBoolSort)
 }
 
 case class IntVar() extends Tree[IntSort] {
   private[dsl] def build(z3 : Z3Context) = z3.mkFreshConst("I", z3.mkIntSort)
+}
+
+case class CharVar() extends Tree[BVSort] {
+  private[dsl] def build(z3 : Z3Context) = z3.mkFreshConst("BV", z3.mkBVSort(16))
 }
 
 case class IntSetVar() extends Tree[SetSort] {

--- a/src/main/scala/z3/scala/dsl/Trees.scala
+++ b/src/main/scala/z3/scala/dsl/Trees.scala
@@ -1,6 +1,6 @@
 package z3.scala.dsl
 
-import z3.scala.{Z3AST,Z3Context}
+import z3.scala.{Z3AST, Z3Context}
 
 sealed trait TopSort
 sealed trait BoolSort extends TopSort
@@ -25,20 +25,22 @@ sealed trait Tree[+T >: BottomSort <: TopSort] {
   }
 }
 
-/** Instances of Val should never be created manually, but rather always
- * through a ValHandler. The type parameter refers to a Scala type for a
- * value that the user wishes to obtain through a call to choose, find or
- * findAll. */
-abstract class Val[A] extends Tree[BottomSort] {
+/** The type parameter refers to a Scala type for a value that the user
+ * wishes to obtain through a call to choose, find or findAll. */
+class Val[A : ValHandler] {
+  val tree: Tree[_ >: BottomSort <: TopSort] = implicitly[ValHandler[A]].construct
+}
+
+abstract class ValTree[S >: BottomSort <: TopSort] extends Tree[S] {
   import Operands._
 
   // def ===(other : Val[A]) : BoolOperand = {
   //   new BoolOperand(Eq(this, other))
-  // } 
+  // }
 
   //def !==(other : Val[A]) : BoolOperand = {
   //  new BoolOperand(Distinct(this, other))
-  //} 
+  //}
 
   // This is more general.
   def ===(other : Tree[BottomSort]) : BoolOperand = {
@@ -47,7 +49,7 @@ abstract class Val[A] extends Tree[BottomSort] {
 
   def !==(other : Tree[BottomSort]) : BoolOperand = {
     new BoolOperand(Distinct(this, other))
-  } 
+  }
 
   // Unsafe as such. Better would be to have this in Tree itself, and restrict
   // it to trees of array sorts.

--- a/src/main/scala/z3/scala/dsl/ValHandler.scala
+++ b/src/main/scala/z3/scala/dsl/ValHandler.scala
@@ -20,9 +20,11 @@ abstract class ValHandler[A : Default] {
   /** Z3 code to construct a sort representing the Scala A type. */
   def mkSort(z3 : Z3Context) : Z3Sort
 
-  /** Constructs a Val[A], i.e. the representation of a variable of type A. */
-  def construct : Val[A] = new Val[A] {
-    def build(z3 : Z3Context) = z3.mkFreshConst("valCst", mkSort(z3))
+  type ValSort >: BottomSort <: TopSort
+
+  /** Constructs a ValTree[A], i.e. the representation of a variable of type A. */
+  def construct: Tree[ValSort] = new ValTree[ValSort] {
+    override def build(z3: Z3Context): Z3AST = z3.mkFreshConst("valCst", mkSort(z3))
   }
 
   def convert(model : Z3Model, ast : Z3AST) : A

--- a/src/main/scala/z3/scala/dsl/package.scala
+++ b/src/main/scala/z3/scala/dsl/package.scala
@@ -40,6 +40,10 @@ package object dsl {
 
   implicit def intOperandToIntTree(operand : IntOperand) : Tree[IntSort] = operand.tree.asInstanceOf[Tree[IntSort]]
 
+  implicit def charValueToBVTree(value : Char) : Tree[BVSort] = CharConstant(value)
+
+  implicit def charValueToBVOperand(value : Char) : BitVectorOperand = new BitVectorOperand(CharConstant(value))
+
   implicit def bvTreeToBVOperand[T >: BottomSort <: BVSort](tree : Tree[T]) : BitVectorOperand =
     new BitVectorOperand(tree)
 
@@ -77,6 +81,13 @@ package object dsl {
 
     def convert(model : Z3Model, ast : Z3AST) : Int =
       model.evalAs[Int](ast).getOrElse(0)
+  }
+
+  implicit object CharValHandler extends ValHandler[Char] {
+    def mkSort(z3 : Z3Context) : Z3Sort = z3.mkBVSort(16)
+
+    def convert(model : Z3Model, ast : Z3AST) : Char =
+      model.evalAs[Char](ast).getOrElse('\u0000')
   }
 
   /** Instances of this class are used to represent models of Z3 maps, which
@@ -266,6 +277,10 @@ package object dsl {
 
   implicit object DefaultBoolean extends Default[Boolean] {
     val value = true
+  }
+
+  implicit object DefaultChar extends Default[Char] {
+    val value = '\u0000'
   }
 
   implicit def liftDefaultToSet[A : Default] : Default[Set[A]] = {

--- a/src/main/scala/z3/scala/dsl/package.scala
+++ b/src/main/scala/z3/scala/dsl/package.scala
@@ -40,6 +40,11 @@ package object dsl {
 
   implicit def intOperandToIntTree(operand : IntOperand) : Tree[IntSort] = operand.tree.asInstanceOf[Tree[IntSort]]
 
+  implicit def bvTreeToBVOperand[T >: BottomSort <: BVSort](tree : Tree[T]) : BitVectorOperand =
+    new BitVectorOperand(tree)
+
+  implicit def bvOperandToBVTree(operand : BitVectorOperand) : Tree[BVSort] = operand.tree.asInstanceOf[Tree[BVSort]]
+
   implicit def z3ASTToSetOperand(ast : Z3AST) : SetOperand = {
     // TODO how do we check the type (set of any type?) here?
     new SetOperand(Z3ASTWrapper[SetSort](ast))

--- a/src/main/scala/z3/scala/dsl/package.scala
+++ b/src/main/scala/z3/scala/dsl/package.scala
@@ -67,6 +67,32 @@ package object dsl {
 
   implicit def setOperandToSetTree(operand : SetOperand) : Tree[SetSort] = operand.tree.asInstanceOf[Tree[SetSort]]
 
+  // All default values
+
+  implicit object DefaultInt extends Default[Int] {
+    val value = 0
+  }
+
+  implicit object DefaultBoolean extends Default[Boolean] {
+    val value = true
+  }
+
+  implicit object DefaultChar extends Default[Char] {
+    val value = '\u0000'
+  }
+
+  implicit def liftDefaultToSet[A : Default] : Default[Set[A]] = {
+    new Default[Set[A]] {
+      val value = Set.empty[A]
+    }
+  }
+
+  implicit def liftDefaultToFun[A,B : Default] : Default[A=>B] = {
+    new Default[A=>B] {
+      val value = ((a : A) => implicitly[Default[B]].value)
+    }
+  }
+
   // Predefined ValHandler's
 
   implicit object BooleanValHandler extends ValHandler[Boolean] {
@@ -267,32 +293,6 @@ package object dsl {
       val result3 = vh3.convert(m, valAST3)
       (result1,result2,result3)
     })
-  }
-
-  // All default values
-
-  implicit object DefaultInt extends Default[Int] {
-    val value = 0
-  }
-
-  implicit object DefaultBoolean extends Default[Boolean] {
-    val value = true
-  }
-
-  implicit object DefaultChar extends Default[Char] {
-    val value = '\u0000'
-  }
-
-  implicit def liftDefaultToSet[A : Default] : Default[Set[A]] = {
-    new Default[Set[A]] {
-      val value = Set.empty[A]
-    }
-  }
-
-  implicit def liftDefaultToFun[A,B : Default] : Default[A=>B] = {
-    new Default[A=>B] {
-      val value = ((a : A) => implicitly[Default[B]].value)
-    }
   }
 
   implicit def astvectorToSeq(v: Z3ASTVector): Seq[Z3AST] = v.toSeq


### PR DESCRIPTION
This is a tentative to add dsl bindings to bit-vectors.

* Commits 1/4 and 2/4 are only adding missing bindings in `Z3Context` from native layer. So I guess they are OK.

* Commit 3/4 is adding dsl tree bindings only for the operations on bit-vectors. I would need advice on:
  - whether the operands are correctly named (or the symbol is appropriately chosen) in `BitVectorOperands`
  - what name symbol to choose for the remaining ones (shifts, rotates and no-{over|under}flow arithmetic; cf. TODO)

* Commit 4/4 is a tentative to add dsl tree nodes (and corresponding implicits) for the char Java type. This how I use them in my project, but clearly something more general could be added. I need advice on this too.

Also, please tell if the overall code quality and code style are not adequate for ScalaZ3.