### PR TITLE
Exclude ar archives from computing the checksum.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -116,7 +116,7 @@ object ScalaZ3Build extends Build {
     val hashFile = z3Path / ".build-hash"
     def computeHash(): String = {
       hashFiles(listAllFiles(z3Path.asFile).filter { f =>
-        !f.getName.endsWith(".pyc") && !f.isHidden && !f.getName.startsWith(".")
+        !f.getName.endsWith(".pyc") && !f.isHidden && !f.getName.startsWith(".") && !f.getName.endsWith(".a")
       })
     }
 


### PR DESCRIPTION
It looks like ar files change between builds, at least on Mac OS. This fixes the checksum logic to not recompile Z3 every time.