### PR TITLE
Get Native class to load in withinJar

### DIFF
--- a/src/main/java/z3/Z3Wrapper.java
+++ b/src/main/java/z3/Z3Wrapper.java
@@ -47,6 +47,8 @@ public final class Z3Wrapper {
       }
 
       loadFromJar();
+      // We run this to ensure class loading of Native.
+      debug("Z3 version: " + z3VersionString());
     }
 
     private static void debug(String msg) {


### PR DESCRIPTION
This enables a single point of failure for UnsatisfiedLinkError in clients that have fallbacks in place.