### PR TITLE
Make all Mac OS dynamic libraries be relocatable

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -220,10 +220,13 @@ object ScalaZ3Build extends Build {
       val frameworkPath = "/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers"
 
       exec("install_name_tool -id @loader_path/"+z3Name+" "+z3BinFilePath.absolutePath, s)
+      exec("install_name_tool -id @loader_path/"+javaZ3Name+" "+javaZ3BinFilePath.absolutePath, s)
+      // make the dependency to z3 be relative to the caller's location
+      exec("install_name_tool -change "+z3Name+" @loader_path/"+z3Name+" "+javaZ3BinFilePath.absolutePath, s)
 
       exec("gcc -std=gnu89 -o " + libBinFilePath.absolutePath + " " +
            "-dynamiclib" + " " +
-           "-install_name "+extractDir(cs)+soName + " " +
+           "-install_name @loader_path/"+soName + " " +
            "-I" + jdkIncludePath.absolutePath + " " +
            "-I" + jdkMacIncludePath.absolutePath + " " +
            "-I" + frameworkPath + " " +


### PR DESCRIPTION
In order for Mac OS to correctly load `libscalaz3` it needs to be able to find it’s dependencies. They’re `libz3` and `libz3java`. This commit modifies the dependency information in all binaries to use `@loader_path`, which makes them relative to the calling library (or app). This makes the test suite (and stainless) pass all tests via Z3.

More info: https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/RunpathDependentLibraries.html#//apple_ref/doc/uid/TP40008306-SW1

Fix #56