### PR TITLE
feat: add Z3Context.mkSeqNth

### DIFF
--- a/src/main/scala/z3/scala/Z3Context.scala
+++ b/src/main/scala/z3/scala/Z3Context.scala
@@ -591,6 +591,10 @@ sealed class Z3Context(val config: Map[String, String]) {
     new Z3AST(Native.mkSeqAt(this.ptr, seq.ptr, i.ptr), this)
   }
 
+  def mkSeqNth(seq: Z3AST, n: Z3AST): Z3AST = {
+    new Z3AST(Native.mkSeqNth(this.ptr, seq.ptr, n.ptr), this)
+  }
+
   def mkSeqExtract(seq: Z3AST, start: Z3AST, length: Z3AST): Z3AST = {
     new Z3AST(Native.mkSeqExtract(this.ptr, seq.ptr, start.ptr, length.ptr), this)
   }


### PR DESCRIPTION
Add a missing commonly used Seq operation.

Operation | Brief description
-- | --
`(seq.nth s offset)` | Element at offset in s. If offset is out of bounds the result is under-specified. In other words, it is treated as a fresh variable

```scala
def mkSeqNth(seq: Z3AST, n: Z3AST): Z3AST = {
  new Z3AST(Native.mkSeqNth(this.ptr, seq.ptr, n.ptr), this)
}
```

reference: https://microsoft.github.io/z3guide/docs/theories/Sequences/